### PR TITLE
Add site guide chatbot to homepage

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -141,6 +141,256 @@ of Korea, the Korea Foundation for Advanced Studies, and various centers
 at Harvard, Johns Hopkins University, UC Berkeley, and the Blum
 Initiative for Global and Regional Poverty Studies.
 
+## Site guide chatbot
+
+Use the chatbot below to quickly find information across the site without hopping between tabs. Ask about publications, talks, datasets, teaching materials, or anything else on this site.
+
+```{=html}
+<section class="site-chatbot" aria-labelledby="site-chatbot-title">
+  <div class="site-chatbot__header">
+    <h3 id="site-chatbot-title">Ask about anything on this site</h3>
+    <p>Example: “Where can I find datasets about civic tech?”</p>
+  </div>
+  <div class="site-chatbot__controls">
+    <label class="sr-only" for="site-chatbot-input">Ask a question</label>
+    <input id="site-chatbot-input" type="text" placeholder="Ask a question or keywords (e.g., publications on AI)" />
+    <button id="site-chatbot-submit" type="button">Search</button>
+  </div>
+  <div class="site-chatbot__quicklinks" aria-label="Suggested prompts">
+    <button type="button" data-prompt="publications on administrative burden">Publications on administrative burden</button>
+    <button type="button" data-prompt="talks or lectures about civic tech">Talks or lectures about civic tech</button>
+    <button type="button" data-prompt="datasets or open data projects">Datasets or open data projects</button>
+    <button type="button" data-prompt="teaching materials or syllabi">Teaching materials or syllabi</button>
+  </div>
+  <div class="site-chatbot__results" aria-live="polite"></div>
+</section>
+
+<style>
+.site-chatbot {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #f7f7fb;
+  box-shadow: 0 16px 40px rgba(28, 28, 40, 0.08);
+}
+.site-chatbot__header h3 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__header p {
+  margin: 0 0 1rem;
+  color: #4b4b5e;
+}
+.site-chatbot__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__controls input {
+  flex: 1 1 240px;
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #cfd2e6;
+  font-size: 1rem;
+}
+.site-chatbot__controls button {
+  padding: 0.7rem 1.2rem;
+  border-radius: 10px;
+  border: none;
+  background: #283593;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.site-chatbot__controls button:hover {
+  background: #1b2375;
+}
+.site-chatbot__quicklinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__quicklinks button {
+  border: 1px solid #cfd2e6;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.site-chatbot__results {
+  display: grid;
+  gap: 0.75rem;
+}
+.site-chatbot__result {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  border: 1px solid #e6e8f5;
+}
+.site-chatbot__result h4 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__result p {
+  margin: 0 0 0.4rem;
+  color: #4b4b5e;
+}
+.site-chatbot__result a {
+  font-weight: 600;
+  color: #283593;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>
+
+<script>
+const siteChatbotData = [
+  {
+    title: "Publications",
+    url: "publications/pubs.html",
+    description: "Peer-reviewed articles, journals, and research outputs.",
+    keywords: ["publications", "papers", "journals", "articles", "research"]
+  },
+  {
+    title: "Talks & Lectures",
+    url: "talks/talks.html",
+    description: "Invited talks, panels, workshops, and lectures.",
+    keywords: ["talks", "lectures", "panels", "workshops", "speaking"]
+  },
+  {
+    title: "Datasets & Data",
+    url: "datasets/data.html",
+    description: "Open datasets, data resources, and reproducible research assets.",
+    keywords: ["datasets", "data", "open data", "resources", "download"]
+  },
+  {
+    title: "Teaching",
+    url: "teaching/teaching.html",
+    description: "Courses, syllabi, teaching materials, and mentorship.",
+    keywords: ["teaching", "courses", "syllabi", "class", "students"]
+  },
+  {
+    title: "Software",
+    url: "software/software.html",
+    description: "Open-source tools, packages, and civic tech projects.",
+    keywords: ["software", "tools", "packages", "code", "civic tech"]
+  },
+  {
+    title: "Community Building",
+    url: "community_building/community.html",
+    description: "Community initiatives, convenings, and public engagement.",
+    keywords: ["community", "engagement", "roundtables", "networks"]
+  },
+  {
+    title: "Book Project",
+    url: "book_projects/books.html",
+    description: "Updates and chapters from the book project Unseen and Uncounted.",
+    keywords: ["book", "unseen and uncounted", "chapters", "project"]
+  },
+  {
+    title: "Awards",
+    url: "awards/awards.html",
+    description: "Awards and honors recognizing research and public service.",
+    keywords: ["awards", "honors", "recognition"]
+  },
+  {
+    title: "Office Hours",
+    url: "office_hour/office_hour.html",
+    description: "Weekly office hour schedule and how to book a slot.",
+    keywords: ["office hours", "meeting", "calendar", "schedule"]
+  },
+  {
+    title: "Personal Essays",
+    url: "essays/essays.html",
+    description: "Personal writing, reflections, and essays.",
+    keywords: ["personal", "essays", "writing", "reflections"]
+  },
+  {
+    title: "Contact & Collaboration",
+    url: "index.html#get-in-touch--collaborate",
+    description: "Reach out for collaboration, chat, or speaking opportunities.",
+    keywords: ["contact", "email", "collaborate", "reach out"]
+  }
+];
+
+const chatbotInput = document.getElementById("site-chatbot-input");
+const chatbotButton = document.getElementById("site-chatbot-submit");
+const chatbotResults = document.querySelector(".site-chatbot__results");
+const promptButtons = document.querySelectorAll(".site-chatbot__quicklinks button");
+
+const renderResults = (matches, query) => {
+  if (matches.length === 0) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>No matches yet</h4>
+      <p>I couldn't find a specific page for “${query}”. Try a broader keyword like “publications”, “talks”, or “datasets”.</p>
+    </div>`;
+    return;
+  }
+
+  chatbotResults.innerHTML = matches.map(match => `
+    <div class="site-chatbot__result">
+      <h4>${match.title}</h4>
+      <p>${match.description}</p>
+      <a href="${match.url}">Go to ${match.title}</a>
+    </div>
+  `).join("");
+};
+
+const findMatches = (query) => {
+  const normalized = query.toLowerCase();
+  const tokens = normalized.split(/[\s,]+/).filter(Boolean);
+  return siteChatbotData
+    .map(item => {
+      const keywordHits = item.keywords.filter(keyword => normalized.includes(keyword)).length;
+      const tokenHits = tokens.filter(token => item.title.toLowerCase().includes(token) || item.description.toLowerCase().includes(token)).length;
+      const score = keywordHits * 2 + tokenHits;
+      return { ...item, score };
+    })
+    .filter(item => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+};
+
+const handleSearch = (query) => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>Try a topic</h4>
+      <p>Ask about publications, teaching, datasets, software, or community work.</p>
+    </div>`;
+    return;
+  }
+  const matches = findMatches(trimmed);
+  renderResults(matches, trimmed);
+};
+
+chatbotButton.addEventListener("click", () => handleSearch(chatbotInput.value));
+chatbotInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    handleSearch(chatbotInput.value);
+  }
+});
+promptButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    chatbotInput.value = button.dataset.prompt;
+    handleSearch(chatbotInput.value);
+  });
+});
+
+handleSearch("publications");
+</script>
+```
+
 <details>
 
 <summary>📧 <strong>Get in Touch / Collaborate</strong></summary>


### PR DESCRIPTION
### Motivation
- Provide a lightweight on-page chatbot so visitors can quickly find site content without navigating multiple tabs or menus.
- Surface key site sections (publications, talks, datasets, teaching, software, etc.) via client-side search to improve discoverability.

### Description
- Inserted a new `## Site guide chatbot` section into `index.qmd` that renders an accessible HTML widget with an input, search button, suggested prompts, and result cards.
- Added scoped CSS styles to match the site aesthetic and ensure responsive layout for the chatbot UI.
- Added client-side JavaScript (`siteChatbotData`) that contains site index entries and a lightweight token/keyword matching algorithm to return ranked matches and route visitors to the corresponding pages.
- The widget runs an initial `handleSearch("publications")` on load and wires prompt buttons and keyboard interaction (Enter key) to the search handler.

### Testing
- Attempted to render the page with `quarto render index.qmd`, but the command failed with `command not found: quarto`, so a local site build could not be validated.
- Inspected the updated `index.qmd` and confirmed the chatbot markup, CSS, and JS were added; the file was staged and committed successfully with `git commit`.
- No automated unit tests were added or executed for the new client-side logic due to the environment limitation preventing a full site build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752f78d20483308993bb9fbe752c2e)