### PR TITLE
Chatbot: use Quarto search.json with lightweight scoring and highlights

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -141,6 +141,335 @@ of Korea, the Korea Foundation for Advanced Studies, and various centers
 at Harvard, Johns Hopkins University, UC Berkeley, and the Blum
 Initiative for Global and Regional Poverty Studies.
 
+## Site guide chatbot
+
+Use the chatbot below to quickly find information across the site without hopping between tabs. Ask about publications, talks, datasets, teaching materials, or anything else on this site.
+
+```{=html}
+<section class="site-chatbot" aria-labelledby="site-chatbot-title">
+  <div class="site-chatbot__header">
+    <h3 id="site-chatbot-title">Ask about anything on this site</h3>
+    <p>Example: “Where can I find datasets about civic tech?”</p>
+  </div>
+  <div class="site-chatbot__controls">
+    <label class="sr-only" for="site-chatbot-input">Ask a question</label>
+    <input id="site-chatbot-input" type="text" placeholder="Ask a question or keywords (e.g., publications on AI)" />
+    <button id="site-chatbot-submit" type="button">Search</button>
+  </div>
+  <div class="site-chatbot__quicklinks" aria-label="Suggested prompts">
+    <button type="button" data-prompt="publications on administrative burden">Publications on administrative burden</button>
+    <button type="button" data-prompt="talks or lectures about civic tech">Talks or lectures about civic tech</button>
+    <button type="button" data-prompt="datasets or open data projects">Datasets or open data projects</button>
+    <button type="button" data-prompt="teaching materials or syllabi">Teaching materials or syllabi</button>
+  </div>
+  <div class="site-chatbot__results" aria-live="polite"></div>
+</section>
+
+<style>
+.site-chatbot {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #f7f7fb;
+  box-shadow: 0 16px 40px rgba(28, 28, 40, 0.08);
+}
+.site-chatbot__header h3 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__header p {
+  margin: 0 0 1rem;
+  color: #4b4b5e;
+}
+.site-chatbot__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__controls input {
+  flex: 1 1 240px;
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #cfd2e6;
+  font-size: 1rem;
+}
+.site-chatbot__controls button {
+  padding: 0.7rem 1.2rem;
+  border-radius: 10px;
+  border: none;
+  background: #283593;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.site-chatbot__controls button:hover {
+  background: #1b2375;
+}
+.site-chatbot__quicklinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__quicklinks button {
+  border: 1px solid #cfd2e6;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.site-chatbot__results {
+  display: grid;
+  gap: 0.75rem;
+}
+.site-chatbot__result {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  border: 1px solid #e6e8f5;
+}
+.site-chatbot__result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.site-chatbot__tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #e8eaf6;
+  color: #283593;
+  white-space: nowrap;
+}
+.site-chatbot__result h4 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__result p {
+  margin: 0 0 0.4rem;
+  color: #4b4b5e;
+}
+.site-chatbot__result a {
+  font-weight: 600;
+  color: #283593;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+const siteChatbotData = [
+  {
+    title: "Publications",
+    url: "publications/pubs.html",
+    description: "Peer-reviewed articles, journals, and research outputs.",
+    type: "Tab",
+    keywords: ["publications", "papers", "journals", "articles", "research"]
+  },
+  {
+    title: "Talks & Lectures",
+    url: "talks/talks.html",
+    description: "Invited talks, panels, workshops, and lectures.",
+    type: "Tab",
+    keywords: ["talks", "lectures", "panels", "workshops", "speaking"]
+  },
+  {
+    title: "Datasets & Data",
+    url: "datasets/data.html",
+    description: "Open datasets, data resources, and reproducible research assets.",
+    type: "Tab",
+    keywords: ["datasets", "data", "open data", "resources", "download"]
+  },
+  {
+    title: "Teaching",
+    url: "teaching/teaching.html",
+    description: "Courses, syllabi, teaching materials, and mentorship.",
+    type: "Tab",
+    keywords: ["teaching", "courses", "syllabi", "class", "students"]
+  },
+  {
+    title: "Software",
+    url: "software/software.html",
+    description: "Open-source tools, packages, and civic tech projects.",
+    type: "Tab",
+    keywords: ["software", "tools", "packages", "code", "civic tech"]
+  },
+  {
+    title: "Community Building",
+    url: "community_building/community.html",
+    description: "Community initiatives, convenings, and public engagement.",
+    type: "Tab",
+    keywords: ["community", "engagement", "roundtables", "networks"]
+  },
+  {
+    title: "Book Project",
+    url: "book_projects/books.html",
+    description: "Updates and chapters from the book project Unseen and Uncounted.",
+    type: "Tab",
+    keywords: ["book", "unseen and uncounted", "chapters", "project"]
+  },
+  {
+    title: "Awards",
+    url: "awards/awards.html",
+    description: "Awards and honors recognizing research and public service.",
+    type: "Tab",
+    keywords: ["awards", "honors", "recognition"]
+  },
+  {
+    title: "Office Hours",
+    url: "office_hour/office_hour.html",
+    description: "Weekly office hour schedule and how to book a slot.",
+    type: "Tab",
+    keywords: ["office hours", "meeting", "calendar", "schedule"]
+  },
+  {
+    title: "Personal Essays",
+    url: "essays/essays.html",
+    description: "Personal writing, reflections, and essays.",
+    type: "Tab",
+    keywords: ["personal", "essays", "writing", "reflections"]
+  },
+  {
+    title: "Contact & Collaboration",
+    url: "index.html#get-in-touch--collaborate",
+    description: "Reach out for collaboration, chat, or speaking opportunities.",
+    type: "Highlight",
+    keywords: ["contact", "email", "collaborate", "reach out"]
+  },
+  {
+    title: "Email Jae directly",
+    url: "mailto:jaeyeonkim@hks.harvard.edu",
+    description: "Send a note about speaking, collaboration, or research.",
+    type: "Highlight",
+    keywords: ["email", "contact", "reach out", "collaboration", "speaking"]
+  },
+  {
+    title: "Book the weekly office hour",
+    url: "https://calendly.com/jaeyeonkim-hks/30min",
+    description: "Grab a 30-minute slot to discuss civic tech.",
+    type: "Highlight",
+    keywords: ["office hours", "calendly", "meeting", "chat", "office hour"]
+  },
+  {
+    title: "Download the CV",
+    url: "CV_Jae_Yeon_Kim.pdf",
+    description: "Latest curriculum vitae (PDF).",
+    type: "Highlight",
+    keywords: ["cv", "resume", "vita", "curriculum vitae"]
+  },
+  {
+    title: "Better Government Lab",
+    url: "https://www.bettergovernmentlab.org/our-team",
+    description: "Learn about Jae's affiliation with the Better Government Lab.",
+    type: "Highlight",
+    keywords: ["better government lab", "bgl", "affiliation", "team"]
+  },
+  {
+    title: "Data for Good Roundtables",
+    url: "https://sites.google.com/view/d4g-roundtables?usp=sharing",
+    description: "A safe and brave space for academics and practitioners.",
+    type: "Highlight",
+    keywords: ["data for good", "roundtables", "community", "events"]
+  },
+  {
+    title: "GovAI Coalition",
+    url: "https://www.sanjoseca.gov/your-government/departments-offices/information-technology/ai-reviews-algorithm-register/govai-coalition",
+    description: "Learn about the GovAI Coalition advisory role.",
+    type: "Highlight",
+    keywords: ["govai", "coalition", "ai", "advisory"]
+  }
+];
+
+const chatbotInput = document.getElementById("site-chatbot-input");
+const chatbotButton = document.getElementById("site-chatbot-submit");
+const chatbotResults = document.querySelector(".site-chatbot__results");
+const promptButtons = document.querySelectorAll(".site-chatbot__quicklinks button");
+
+if (!chatbotInput || !chatbotButton || !chatbotResults) {
+  return;
+}
+
+const renderResults = (matches, query) => {
+  if (matches.length === 0) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>No matches yet</h4>
+      <p>I couldn't find a specific page for “${query}”. Try a broader keyword like “publications”, “talks”, or “datasets”.</p>
+    </div>`;
+    return;
+  }
+
+  chatbotResults.innerHTML = matches.map(match => `
+    <div class="site-chatbot__result">
+      <div class="site-chatbot__result-header">
+        <h4>${match.title}</h4>
+        <span class="site-chatbot__tag">${match.type}</span>
+      </div>
+      <p>${match.description}</p>
+      <a href="${match.url}">Go to ${match.title}</a>
+    </div>
+  `).join("");
+};
+
+const findMatches = (query) => {
+  const normalized = query.toLowerCase();
+  const tokens = normalized.split(/[\s,]+/).filter(Boolean);
+  return siteChatbotData
+    .map(item => {
+      const keywordHits = item.keywords.filter(keyword => normalized.includes(keyword)).length;
+      const tokenHits = tokens.filter(token => item.title.toLowerCase().includes(token) || item.description.toLowerCase().includes(token)).length;
+      const score = keywordHits * 2 + tokenHits;
+      return { ...item, score };
+    })
+    .filter(item => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+};
+
+const handleSearch = (query) => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>Try a topic</h4>
+      <p>Ask about publications, teaching, datasets, software, or community work.</p>
+    </div>`;
+    return;
+  }
+  const matches = findMatches(trimmed);
+  renderResults(matches, trimmed);
+};
+
+chatbotButton.addEventListener("click", () => handleSearch(chatbotInput.value));
+chatbotInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    handleSearch(chatbotInput.value);
+  }
+});
+promptButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    chatbotInput.value = button.dataset.prompt;
+    handleSearch(chatbotInput.value);
+  });
+});
+
+handleSearch("publications");
+});
+</script>
+```
+
 <details>
 
 <summary>📧 <strong>Get in Touch / Collaborate</strong></summary>

--- a/index.qmd
+++ b/index.qmd
@@ -141,6 +141,256 @@ of Korea, the Korea Foundation for Advanced Studies, and various centers
 at Harvard, Johns Hopkins University, UC Berkeley, and the Blum
 Initiative for Global and Regional Poverty Studies.
 
+## Site guide chatbot
+
+Use the chatbot below to quickly find information across the site without hopping between tabs. Ask about publications, talks, datasets, teaching materials, or anything else on this site.
+
+```{=html}
+<section class="site-chatbot" aria-labelledby="site-chatbot-title">
+  <div class="site-chatbot__header">
+    <h3 id="site-chatbot-title">Ask about anything on this site</h3>
+    <p>Example: “Where can I find datasets about civic tech?”</p>
+  </div>
+  <div class="site-chatbot__controls">
+    <label class="sr-only" for="site-chatbot-input">Ask a question</label>
+    <input id="site-chatbot-input" type="text" placeholder="Ask a question or keywords (e.g., publications on AI)" />
+    <button id="site-chatbot-submit" type="button">Search</button>
+  </div>
+  <div class="site-chatbot__quicklinks" aria-label="Suggested prompts">
+    <button type="button" data-prompt="publications on administrative burden">Publications on administrative burden</button>
+    <button type="button" data-prompt="talks or lectures about civic tech">Talks or lectures about civic tech</button>
+    <button type="button" data-prompt="datasets or open data projects">Datasets or open data projects</button>
+    <button type="button" data-prompt="teaching materials or syllabi">Teaching materials or syllabi</button>
+  </div>
+  <div class="site-chatbot__results" aria-live="polite"></div>
+</section>
+
+<style>
+.site-chatbot {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #f7f7fb;
+  box-shadow: 0 16px 40px rgba(28, 28, 40, 0.08);
+}
+.site-chatbot__header h3 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__header p {
+  margin: 0 0 1rem;
+  color: #4b4b5e;
+}
+.site-chatbot__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__controls input {
+  flex: 1 1 240px;
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #cfd2e6;
+  font-size: 1rem;
+}
+.site-chatbot__controls button {
+  padding: 0.7rem 1.2rem;
+  border-radius: 10px;
+  border: none;
+  background: #283593;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.site-chatbot__controls button:hover {
+  background: #1b2375;
+}
+.site-chatbot__quicklinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__quicklinks button {
+  border: 1px solid #cfd2e6;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.site-chatbot__results {
+  display: grid;
+  gap: 0.75rem;
+}
+.site-chatbot__result {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  border: 1px solid #e6e8f5;
+}
+.site-chatbot__result h4 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__result p {
+  margin: 0 0 0.4rem;
+  color: #4b4b5e;
+}
+.site-chatbot__result a {
+  font-weight: 600;
+  color: #283593;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>
+
+<script>
+const siteChatbotData = [
+  {
+    title: "Publications",
+    url: "publications/pubs.html",
+    description: "Peer-reviewed articles, journals, and research outputs.",
+    keywords: ["publications", "papers", "journals", "articles", "research"]
+  },
+  {
+    title: "Talks & Lectures",
+    url: "talks/talks.html",
+    description: "Invited talks, panels, workshops, and lectures.",
+    keywords: ["talks", "lectures", "panels", "workshops", "speaking"]
+  },
+  {
+    title: "Datasets & Data",
+    url: "datasets/data.html",
+    description: "Open datasets, data resources, and reproducible research assets.",
+    keywords: ["datasets", "data", "open data", "resources", "download"]
+  },
+  {
+    title: "Teaching",
+    url: "teaching/teaching.html",
+    description: "Courses, syllabi, teaching materials, and mentorship.",
+    keywords: ["teaching", "courses", "syllabi", "class", "students"]
+  },
+  {
+    title: "Software",
+    url: "software/software.html",
+    description: "Open-source tools, packages, and civic tech projects.",
+    keywords: ["software", "tools", "packages", "code", "civic tech"]
+  },
+  {
+    title: "Community Building",
+    url: "community_building/community.html",
+    description: "Community initiatives, convenings, and public engagement.",
+    keywords: ["community", "engagement", "roundtables", "networks"]
+  },
+  {
+    title: "Book Project",
+    url: "book_projects/books.html",
+    description: "Updates and chapters from the book project Unseen and Uncounted.",
+    keywords: ["book", "unseen and uncounted", "chapters", "project"]
+  },
+  {
+    title: "Awards",
+    url: "awards/awards.html",
+    description: "Awards and honors recognizing research and public service.",
+    keywords: ["awards", "honors", "recognition"]
+  },
+  {
+    title: "Office Hours",
+    url: "office_hour/office_hour.html",
+    description: "Weekly office hour schedule and how to book a slot.",
+    keywords: ["office hours", "meeting", "calendar", "schedule"]
+  },
+  {
+    title: "Personal Essays",
+    url: "essays/essays.html",
+    description: "Personal writing, reflections, and essays.",
+    keywords: ["personal", "essays", "writing", "reflections"]
+  },
+  {
+    title: "Contact & Collaboration",
+    url: "index.html#get-in-touch--collaborate",
+    description: "Reach out for collaboration, chat, or speaking opportunities.",
+    keywords: ["contact", "email", "collaborate", "reach out"]
+  }
+];
+
+const chatbotInput = document.getElementById("site-chatbot-input");
+const chatbotButton = document.getElementById("site-chatbot-submit");
+const chatbotResults = document.querySelector(".site-chatbot__results");
+const promptButtons = document.querySelectorAll(".site-chatbot__quicklinks button");
+
+const renderResults = (matches, query) => {
+  if (matches.length === 0) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>No matches yet</h4>
+      <p>I couldn't find a specific page for “${query}”. Try a broader keyword like “publications”, “talks”, or “datasets”.</p>
+    </div>`;
+    return;
+  }
+
+  chatbotResults.innerHTML = matches.map(match => `
+    <div class="site-chatbot__result">
+      <h4>${match.title}</h4>
+      <p>${match.description}</p>
+      <a href="${match.url}">Go to ${match.title}</a>
+    </div>
+  `).join("");
+};
+
+const findMatches = (query) => {
+  const normalized = query.toLowerCase();
+  const tokens = normalized.split(/[\s,]+/).filter(Boolean);
+  return siteChatbotData
+    .map(item => {
+      const keywordHits = item.keywords.filter(keyword => normalized.includes(keyword)).length;
+      const tokenHits = tokens.filter(token => item.title.toLowerCase().includes(token) || item.description.toLowerCase().includes(token)).length;
+      const score = keywordHits * 2 + tokenHits;
+      return { ...item, score };
+    })
+    .filter(item => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+};
+
+const handleSearch = (query) => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>Try a topic</h4>
+      <p>Ask about publications, teaching, datasets, software, or community work.</p>
+    </div>`;
+    return;
+  }
+  const matches = findMatches(trimmed);
+  renderResults(matches, trimmed);
+};
+
+chatbotButton.addEventListener("click", () => handleSearch(chatbotInput.value));
+chatbotInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    handleSearch(chatbotInput.value);
+  }
+});
+promptButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    chatbotInput.value = button.dataset.prompt;
+    handleSearch(chatbotInput.value);
+  });
+});
+
+handleSearch("publications");
+</script>
+```
+
 <details>
 
 <summary>📧 <strong>Get in Touch / Collaborate</strong></summary>

--- a/index.qmd
+++ b/index.qmd
@@ -141,6 +141,368 @@ of Korea, the Korea Foundation for Advanced Studies, and various centers
 at Harvard, Johns Hopkins University, UC Berkeley, and the Blum
 Initiative for Global and Regional Poverty Studies.
 
+## Site guide chatbot
+
+Use the chatbot below to quickly find information across the site without hopping between tabs. Ask about publications, talks, datasets, teaching materials, or anything else on this site.
+
+```{=html}
+<section class="site-chatbot" aria-labelledby="site-chatbot-title">
+  <div class="site-chatbot__header">
+    <h3 id="site-chatbot-title">Ask about anything on this site</h3>
+    <p>Example: “Where can I find datasets about civic tech?”</p>
+  </div>
+  <div class="site-chatbot__controls">
+    <label class="sr-only" for="site-chatbot-input">Ask a question</label>
+    <input id="site-chatbot-input" type="text" placeholder="Ask a question or keywords (e.g., publications on AI)" />
+    <button id="site-chatbot-submit" type="button">Search</button>
+  </div>
+  <div class="site-chatbot__quicklinks" aria-label="Suggested prompts">
+    <button type="button" data-prompt="publications on administrative burden">Publications on administrative burden</button>
+    <button type="button" data-prompt="talks or lectures about civic tech">Talks or lectures about civic tech</button>
+    <button type="button" data-prompt="datasets or open data projects">Datasets or open data projects</button>
+    <button type="button" data-prompt="teaching materials or syllabi">Teaching materials or syllabi</button>
+  </div>
+  <div class="site-chatbot__results" aria-live="polite"></div>
+</section>
+
+<style>
+.site-chatbot {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #f7f7fb;
+  box-shadow: 0 16px 40px rgba(28, 28, 40, 0.08);
+}
+.site-chatbot__header h3 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__header p {
+  margin: 0 0 1rem;
+  color: #4b4b5e;
+}
+.site-chatbot__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__controls input {
+  flex: 1 1 240px;
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #cfd2e6;
+  font-size: 1rem;
+}
+.site-chatbot__controls button {
+  padding: 0.7rem 1.2rem;
+  border-radius: 10px;
+  border: none;
+  background: #283593;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.site-chatbot__controls button:hover {
+  background: #1b2375;
+}
+.site-chatbot__quicklinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.site-chatbot__quicklinks button {
+  border: 1px solid #cfd2e6;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.site-chatbot__results {
+  display: grid;
+  gap: 0.75rem;
+}
+.site-chatbot__result {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  border: 1px solid #e6e8f5;
+}
+.site-chatbot__result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.site-chatbot__tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #e8eaf6;
+  color: #283593;
+  white-space: nowrap;
+}
+.site-chatbot__result h4 {
+  margin: 0 0 0.25rem;
+}
+.site-chatbot__result p {
+  margin: 0 0 0.4rem;
+  color: #4b4b5e;
+}
+.site-chatbot__result a {
+  font-weight: 600;
+  color: #283593;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+const staticHighlights = [
+  {
+    title: "Publications",
+    url: "publications/pubs.html",
+    description: "Peer-reviewed articles, journals, and research outputs.",
+    type: "Tab",
+    keywords: ["publications", "papers", "journals", "articles", "research"]
+  },
+  {
+    title: "Talks & Lectures",
+    url: "talks/talks.html",
+    description: "Invited talks, panels, workshops, and lectures.",
+    type: "Tab",
+    keywords: ["talks", "lectures", "panels", "workshops", "speaking"]
+  },
+  {
+    title: "Datasets & Data",
+    url: "datasets/data.html",
+    description: "Open datasets, data resources, and reproducible research assets.",
+    type: "Tab",
+    keywords: ["datasets", "data", "open data", "resources", "download"]
+  },
+  {
+    title: "Teaching",
+    url: "teaching/teaching.html",
+    description: "Courses, syllabi, teaching materials, and mentorship.",
+    type: "Tab",
+    keywords: ["teaching", "courses", "syllabi", "class", "students"]
+  },
+  {
+    title: "Software",
+    url: "software/software.html",
+    description: "Open-source tools, packages, and civic tech projects.",
+    type: "Tab",
+    keywords: ["software", "tools", "packages", "code", "civic tech"]
+  },
+  {
+    title: "Community Building",
+    url: "community_building/community.html",
+    description: "Community initiatives, convenings, and public engagement.",
+    type: "Tab",
+    keywords: ["community", "engagement", "roundtables", "networks"]
+  },
+  {
+    title: "Book Project",
+    url: "book_projects/books.html",
+    description: "Updates and chapters from the book project Unseen and Uncounted.",
+    type: "Tab",
+    keywords: ["book", "unseen and uncounted", "chapters", "project"]
+  },
+  {
+    title: "Awards",
+    url: "awards/awards.html",
+    description: "Awards and honors recognizing research and public service.",
+    type: "Tab",
+    keywords: ["awards", "honors", "recognition"]
+  },
+  {
+    title: "Office Hours",
+    url: "office_hour/office_hour.html",
+    description: "Weekly office hour schedule and how to book a slot.",
+    type: "Tab",
+    keywords: ["office hours", "meeting", "calendar", "schedule"]
+  },
+  {
+    title: "Personal Essays",
+    url: "essays/essays.html",
+    description: "Personal writing, reflections, and essays.",
+    type: "Tab",
+    keywords: ["personal", "essays", "writing", "reflections"]
+  },
+  {
+    title: "Contact & Collaboration",
+    url: "index.html#get-in-touch--collaborate",
+    description: "Reach out for collaboration, chat, or speaking opportunities.",
+    type: "Highlight",
+    keywords: ["contact", "email", "collaborate", "reach out"]
+  },
+  {
+    title: "Email Jae directly",
+    url: "mailto:jaeyeonkim@hks.harvard.edu",
+    description: "Send a note about speaking, collaboration, or research.",
+    type: "Highlight",
+    keywords: ["email", "contact", "reach out", "collaboration", "speaking"]
+  },
+  {
+    title: "Book the weekly office hour",
+    url: "https://calendly.com/jaeyeonkim-hks/30min",
+    description: "Grab a 30-minute slot to discuss civic tech.",
+    type: "Highlight",
+    keywords: ["office hours", "calendly", "meeting", "chat", "office hour"]
+  },
+  {
+    title: "Download the CV",
+    url: "CV_Jae_Yeon_Kim.pdf",
+    description: "Latest curriculum vitae (PDF).",
+    type: "Highlight",
+    keywords: ["cv", "resume", "vita", "curriculum vitae"]
+  },
+  {
+    title: "Better Government Lab",
+    url: "https://www.bettergovernmentlab.org/our-team",
+    description: "Learn about Jae's affiliation with the Better Government Lab.",
+    type: "Highlight",
+    keywords: ["better government lab", "bgl", "affiliation", "team"]
+  },
+  {
+    title: "Data for Good Roundtables",
+    url: "https://sites.google.com/view/d4g-roundtables?usp=sharing",
+    description: "A safe and brave space for academics and practitioners.",
+    type: "Highlight",
+    keywords: ["data for good", "roundtables", "community", "events"]
+  },
+  {
+    title: "GovAI Coalition",
+    url: "https://www.sanjoseca.gov/your-government/departments-offices/information-technology/ai-reviews-algorithm-register/govai-coalition",
+    description: "Learn about the GovAI Coalition advisory role.",
+    type: "Highlight",
+    keywords: ["govai", "coalition", "ai", "advisory"]
+  }
+];
+
+let dynamicIndex = [];
+const SEARCH_INDEX_URL = "search.json";
+
+const chatbotInput = document.getElementById("site-chatbot-input");
+const chatbotButton = document.getElementById("site-chatbot-submit");
+const chatbotResults = document.querySelector(".site-chatbot__results");
+const promptButtons = document.querySelectorAll(".site-chatbot__quicklinks button");
+
+if (!chatbotInput || !chatbotButton || !chatbotResults) {
+  return;
+}
+
+const renderResults = (matches, query) => {
+  if (matches.length === 0) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>No matches yet</h4>
+      <p>I couldn't find a specific page for “${query}”. Try a broader keyword like “publications”, “talks”, or “datasets”.</p>
+    </div>`;
+    return;
+  }
+
+  chatbotResults.innerHTML = matches.map(match => `
+    <div class="site-chatbot__result">
+      <div class="site-chatbot__result-header">
+        <h4>${match.title}</h4>
+        <span class="site-chatbot__tag">${match.type}</span>
+      </div>
+      <p>${match.description}</p>
+      <a href="${match.url}">Go to ${match.title}</a>
+    </div>
+  `).join("");
+};
+
+const scoreEntry = (entry, tokens) => {
+  const title = entry.title.toLowerCase();
+  const description = (entry.description || "").toLowerCase();
+  const content = (entry.content || "").toLowerCase();
+  const matches = tokens.filter(token =>
+    title.includes(token) || description.includes(token) || content.includes(token)
+  );
+  return matches.length;
+};
+
+const findMatches = (query) => {
+  const normalized = query.toLowerCase();
+  const tokens = normalized.split(/[\s,]+/).filter(Boolean);
+  const merged = [...dynamicIndex, ...staticHighlights];
+  return merged
+    .map(item => {
+      const score = scoreEntry(item, tokens);
+      return { ...item, score };
+    })
+    .filter(item => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6);
+};
+
+const loadSearchIndex = async () => {
+  try {
+    const response = await fetch(SEARCH_INDEX_URL, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error("Search index unavailable");
+    }
+    const data = await response.json();
+    dynamicIndex = data.map(entry => ({
+      title: entry.title || "Untitled page",
+      url: entry.location || entry.url || "#",
+      description: entry.description || entry.summary || "Site content",
+      content: entry.text || entry.content || "",
+      type: entry.section ? "Result" : "Tab"
+    }));
+  } catch (error) {
+    dynamicIndex = [];
+  }
+};
+
+const handleSearch = (query) => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    chatbotResults.innerHTML = `<div class="site-chatbot__result">
+      <h4>Try a topic</h4>
+      <p>Ask about publications, teaching, datasets, software, or community work.</p>
+    </div>`;
+    return;
+  }
+  const matches = findMatches(trimmed);
+  renderResults(matches, trimmed);
+};
+
+chatbotButton.addEventListener("click", () => handleSearch(chatbotInput.value));
+chatbotInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    handleSearch(chatbotInput.value);
+  }
+});
+promptButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    chatbotInput.value = button.dataset.prompt;
+    handleSearch(chatbotInput.value);
+  });
+});
+
+loadSearchIndex().then(() => {
+  handleSearch("publications");
+});
+});
+</script>
+```
+
 <details>
 
 <summary>📧 <strong>Get in Touch / Collaborate</strong></summary>


### PR DESCRIPTION
### Motivation
- Improve the site chatbot from a purely rule-based matcher to a more intelligent search that returns specific page results beyond top-level tabs.
- Surface direct links (CV, mailto, Calendly, external projects) alongside indexed site pages so users can navigate directly to relevant resources.
- Defer and protect initialization until the DOM is ready and handle missing or unavailable search indexes gracefully.

### Description
- Add a chatbot UI block (HTML/CSS) and replace the old static `siteChatbotData` approach with `staticHighlights` plus a `dynamicIndex` loaded from `search.json`.
- Implement `loadSearchIndex`, `scoreEntry`, and `findMatches` to load Quarto's `search.json`, merge it with curated highlights, and rank results by token matches across title, description, and page content.
- Update `renderResults` to show a header with a result `type` tag and limit results; attach event listeners to the input, submit button, and quick-prompt buttons, and defer the initial search until `loadSearchIndex()` completes.
- Add error handling so the chatbot continues to work if the search index fetch fails and keep the DOMContentLoaded guard and element existence checks to avoid runtime errors on pages without the chatbot.

### Testing
- No automated tests were run for this change and no site build/test was executed because a local `quarto` site build was not performed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752f78d20483308993bb9fbe752c2e)